### PR TITLE
Feat: add ability to update token `name` and `symbol`

### DIFF
--- a/src/SDAO.sol
+++ b/src/SDAO.sol
@@ -167,7 +167,7 @@ contract SDAO {
     /**
      * @notice Updates token parameters.
      * @dev There are no mechanisms to prevent governance from changing token parameters more than once.
-     *  We assume that the enforcement will be handle off-chain through governance artifacts.
+     *  We assume that the enforcement will be handled off-chain through governance artifacts.
      * @param what The parameter being changed. One of: "name", "symbol".
      * @param data The updated value for the parameter.
      */

--- a/src/SDAO.sol
+++ b/src/SDAO.sol
@@ -24,7 +24,7 @@ interface IERC1271 {
 /**
  * @title SDAO: SubDAO-level governance token.
  * @dev This is a port from X-Domain Dai implementation: https://www.diffchecker.com/XeqEiDcn/ with additional features:
- *  - Addresses with `ward` permission can update `name` and `symbol`.
+ *      - Actors with owner access (`wards`) can update `name` and `symbol`.
  * @author @amusingaxl
  */
 contract SDAO {

--- a/src/SDAO.sol
+++ b/src/SDAO.sol
@@ -23,7 +23,8 @@ interface IERC1271 {
 
 /**
  * @title SDAO: SubDAO-level governance token.
- * @dev This is a port from X-Domain Dai implementation: https://www.diffchecker.com/XeqEiDcn/
+ * @dev This is a port from X-Domain Dai implementation: https://www.diffchecker.com/XeqEiDcn/ with additional features:
+ *  - Addresses with `ward` permission can update `name` and `symbol`.
  * @author @amusingaxl
  */
 contract SDAO {
@@ -64,6 +65,12 @@ contract SDAO {
      * @param usr The user address.
      */
     event Deny(address indexed usr);
+    /**
+     * @notice A contract parameter was updated.
+     * @param what The parameter being changed. One of: "name", "symbol".
+     * @param data The new value of the parameter.
+     */
+    event File(bytes32 indexed what, string data);
 
     /**
      * @notice Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}.
@@ -155,6 +162,25 @@ contract SDAO {
     function deny(address usr) external auth {
         wards[usr] = 0;
         emit Deny(usr);
+    }
+
+    /**
+     * @notice Updates token parameters.
+     * @dev There are no mechanisms to prevent governance from changing token parameters more than once.
+     *  We assume that the enforcement will be handle off-chain through governance artifacts.
+     * @param what The parameter being changed. One of: "name", "symbol".
+     * @param data The updated value for the parameter.
+     */
+    function file(bytes32 what, string calldata data) external auth {
+        if (what == "name") {
+            name = data;
+        } else if (what == "symbol") {
+            symbol = data;
+        } else {
+            revert("SDAO/file-unrecognized-param");
+        }
+
+        emit File(what, data);
     }
 
     // --- ERC20 Mutations ---

--- a/src/SDAO.t.sol
+++ b/src/SDAO.t.sol
@@ -483,19 +483,12 @@ contract SDAOTest is DssTest {
     }
 
     function testFile() public {
-        checkFileString(address(token), "SDAO", ["name"]);
-        checkFileString(address(token), "SDAO", ["symbol"]);
+        checkFileString(address(token), "SDAO", ["name", "symbol"]);
     }
 
     // There are no checkFileString on DssTest, so we need to implement it here.
 
     event File(bytes32 indexed what, string data);
-
-    function checkFileString(address _base, string memory _contractName, string[1] memory _values) internal {
-        string[] memory values = new string[](1);
-        values[0] = _values[0];
-        checkFileString(_base, _contractName, values);
-    }
 
     /// @dev This is forge-only due to event checking
     function checkFileString(address _base, string memory _contractName, string[] memory _values) internal {
@@ -550,6 +543,19 @@ contract SDAOTest is DssTest {
 
         // Reset admin access to what it was
         GodMode.setWard(_base, address(this), ward);
+    }
+
+    function checkFileString(address _base, string memory _contractName, string[1] memory _values) internal {
+        string[] memory values = new string[](1);
+        values[0] = _values[0];
+        checkFileString(_base, _contractName, values);
+    }
+
+    function checkFileString(address _base, string memory _contractName, string[2] memory _values) internal {
+        string[] memory values = new string[](2);
+        values[0] = _values[0];
+        values[1] = _values[1];
+        checkFileString(_base, _contractName, values);
     }
 }
 

--- a/src/SDAO.t.sol
+++ b/src/SDAO.t.sol
@@ -16,6 +16,7 @@
 pragma solidity =0.8.19;
 
 import {DssTest} from "dss-test/DssTest.sol";
+import {GodMode} from "dss-test/MCD.sol";
 import {SDAO} from "./SDAO.sol";
 
 /**
@@ -36,6 +37,11 @@ contract SDAOTest is DssTest {
         assertEq(token.name(), "Token");
         assertEq(token.symbol(), "TKN");
         assertEq(token.decimals(), 18);
+    }
+
+    function testRevertFileUnsupportedMetadata() public {
+        vm.expectRevert("SDAO/file-unrecognized-param");
+        token.file("decimals", "18");
     }
 
     function testMint() public {
@@ -475,6 +481,88 @@ contract SDAOTest is DssTest {
         vm.startPrank(sender);
         checkModifier(address(token), "SDAO/not-authorized", authedMethods);
     }
+
+    function testFile() public {
+        checkFileString(address(token), "SDAO", ["name"]);
+        checkFileString(address(token), "SDAO", ["symbol"]);
+    }
+
+    // There are no checkFileString on DssTest, so we need to implement it here.
+
+    event File(bytes32 indexed what, string data);
+
+    function checkFileString(address _base, string memory _contractName, string[1] memory _values) internal {
+        string[] memory values = new string[](1);
+        values[0] = _values[0];
+        checkFileString(_base, _contractName, values);
+    }
+
+    /// @dev This is forge-only due to event checking
+    function checkFileString(address _base, string memory _contractName, string[] memory _values) internal {
+        FileStringLike base = FileStringLike(_base);
+        uint256 ward = base.wards(address(this));
+
+        // Ensure we have admin access
+        GodMode.setWard(_base, address(this), 1);
+
+        // First check an invalid value
+        vm.expectRevert(abi.encodePacked(_contractName, "/file-unrecognized-param"));
+        base.file("an invalid value", "");
+
+        // Next check each value is valid and updates the target storage slot
+        for (uint256 i = 0; i < _values.length; i++) {
+            string memory value = _values[i];
+            bytes32 valueB32;
+            assembly {
+                valueB32 := mload(add(value, 32))
+            }
+
+            // Read original value
+            (bool success, bytes memory result) = _base.call(
+                abi.encodeWithSignature(string(abi.encodePacked(value, "()")))
+            );
+            assertTrue(success);
+            string memory origData = abi.decode(result, (string));
+            string memory newData;
+            newData = string.concat(newData, " - NEW");
+
+            // Update value
+            vm.expectEmit(true, false, false, true);
+            emit File(valueB32, newData);
+            base.file(valueB32, newData);
+
+            // Confirm it was updated successfully
+            (success, result) = _base.call(abi.encodeWithSignature(string(abi.encodePacked(value, "()"))));
+            assertTrue(success);
+            string memory data = abi.decode(result, (string));
+            assertEq(data, newData);
+
+            // Reset value to original
+            vm.expectEmit(true, false, false, true);
+            emit File(valueB32, origData);
+            base.file(valueB32, origData);
+        }
+
+        // Finally check that file is authed
+        base.deny(address(this));
+        vm.expectRevert(abi.encodePacked(_contractName, "/not-authorized"));
+        base.file("some value", "");
+
+        // Reset admin access to what it was
+        GodMode.setWard(_base, address(this), ward);
+    }
+}
+
+interface AuthLike {
+    function wards(address) external view returns (uint256);
+
+    function rely(address) external;
+
+    function deny(address) external;
+}
+
+interface FileStringLike is AuthLike {
+    function file(bytes32, string memory) external;
 }
 
 contract SDAOInvariants is DssTest {


### PR DESCRIPTION
SubDAOs might want to rebrand their tokens in the future.

We made `name` and `symbol` updateable by anyone with `ward` access to it. This will most likely be accessible only by the SubDAO Pause Proxy.

Notice that there is no code-level enforcement of how many times such parameters can be changed. If there should be a limit, enforcement must be done off-chain through Governance Artifacts.
