### PR TITLE
FarmingInit: add `stakingToken != rewardsToken` sanity check; add comment about potential issue with `notifyRewardAmount()`

### DIFF
--- a/script/dependencies/phase-0-alpha/FarmingInit.sol
+++ b/script/dependencies/phase-0-alpha/FarmingInit.sol
@@ -29,6 +29,11 @@ struct FarmingInitParams {
 
 library FarmingInit {
     function init(FarmingInitParams memory p) internal {
+        address stakingToken = StakingRewardsLike(p.rewards).stakingToken();
+        address rewardsToken = StakingRewardsLike(p.rewards).rewardsToken();
+
+        require(stakingToken != rewardsToken, "FarmingInit/rewards-token-same-as-staking-token");
+
         require(DssVestWithGemLike(p.vest).gem() == p.ngt, "FarmingInit/vest-gem-mismatch");
         require(DssVestWithGemLike(p.vest).valid(p.vestId), "FarmingInit/vest-invalid-id");
         require(DssVestWithGemLike(p.vest).usr(p.vestId) == p.dist, "FarmingInit/vest-invalid-usr");
@@ -39,8 +44,8 @@ library FarmingInit {
             "FarmingInit/vest-bgn-clf-mismatch"
         );
 
-        require(StakingRewardsLike(p.rewards).rewardsToken() == p.ngt, "FarmingInit/rewards-rewards-token-mismatch");
-        require(StakingRewardsLike(p.rewards).stakingToken() == p.nst, "FarmingInit/rewards-staking-token-mismatch");
+        require(stakingToken == p.nst, "FarmingInit/rewards-staking-token-mismatch");
+        require(rewardsToken == p.ngt, "FarmingInit/rewards-rewards-token-mismatch");
         require(StakingRewardsLike(p.rewards).lastUpdateTime() == 0, "FarmingInit/rewards-last-update-time-invalid");
 
         require(VestedRewardsDistributionLike(p.dist).gem() == p.ngt, "FarmingInit/dist-gem-mismatch");

--- a/script/dependencies/phase-0/FarmingInit.sol
+++ b/script/dependencies/phase-0/FarmingInit.sol
@@ -36,10 +36,15 @@ struct FarmingInitResult {
 
 library FarmingInit {
     function init(FarmingInitParams memory p) internal returns (FarmingInitResult memory r) {
+        address stakingToken = StakingRewardsLike(p.rewards).stakingToken();
+        address rewardsToken = StakingRewardsLike(p.rewards).rewardsToken();
+
+        require(stakingToken != rewardsToken, "FarmingInit/rewards-token-same-as-staking-token");
+
         require(DssVestWithGemLike(p.vest).gem() == p.ngt, "FarmingInit/vest-gem-mismatch");
 
-        require(StakingRewardsLike(p.rewards).rewardsToken() == p.ngt, "FarmingInit/rewards-rewards-token-mismatch");
-        require(StakingRewardsLike(p.rewards).stakingToken() == p.nst, "FarmingInit/rewards-staking-token-mismatch");
+        require(stakingToken == p.nst, "FarmingInit/rewards-staking-token-mismatch");
+        require(rewardsToken == p.ngt, "FarmingInit/rewards-rewards-token-mismatch");
         require(StakingRewardsLike(p.rewards).lastUpdateTime() == 0, "FarmingInit/rewards-last-update-time-invalid");
 
         require(VestedRewardsDistributionLike(p.dist).gem() == p.ngt, "FarmingInit/dist-gem-mismatch");


### PR DESCRIPTION
We need to ensure that `stakingToken != rewardsToken`, otherwise it could lead to staked amounts to be consumed as rewards.

See: https://github.com/cantinasec/review-makerdao-endgametoolkit/pull/25
